### PR TITLE
fix(input-search): fix misaligned search cancel button on Safari

### DIFF
--- a/src/common/style.scss
+++ b/src/common/style.scss
@@ -6,7 +6,7 @@
 
 $input-border-color: #949494;
 $input-focus-border-color: #1a73c5;
-$focus-ring-color: rgba(26, 115, 197, 0.30);
+$focus-ring-color: rgba(26, 115, 197, 0.3);
 $form-select-bg-size: 16px 16px;
 $form-select-padding-x: 15px;
 $input-padding-x: 15px;
@@ -35,83 +35,83 @@ $tooltip-padding-y: 20px;
 // MOVE TO UTKWDS
 
 label {
-    font-size: 1rem;
+	font-size: 1rem;
 }
 
 select.form-select {
-    color: inherit;
+	color: inherit;
 }
 
 .form-check-input {
-    width: 40px;
-    height: 20px;
-    background-color: #f6f6f6;
-    border: 1px solid #949494;
+	width: 40px;
+	height: 20px;
+	background-color: #f6f6f6;
+	border: 1px solid #949494;
 
-    // Switch ON style
-    &:checked {
-        background-color: #2171c2;
-        border-color: #2171c2;
-    }
+	// Switch ON style
+	&:checked {
+		background-color: #2171c2;
+		border-color: #2171c2;
+	}
 }
 
 // Update UTKWDS theme file to this padding
 .button-submit {
-    height: 58px;
-    padding: 0 20px !important;
-    word-break: normal;
+	height: 58px;
+	padding: 0 20px !important;
+	word-break: normal;
 
-    &:hover {
-        color: var(--wp--preset--color--white);
-        background-color: var(--wp--custom--color--river);
-        border-color: var(--wp--custom--color--river);
-    }
+	&:hover {
+		color: var(--wp--preset--color--white);
+		background-color: var(--wp--custom--color--river);
+		border-color: var(--wp--custom--color--river);
+	}
 }
 
 .form-floating {
-    width: 100%;
+	width: 100%;
 
-    input[type="search"] {
-        --bs-form-search-bg-img: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' class='bi bi-search' viewBox='0 0 16 16'%3E%3Cpath d='M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0'/%3E%3C/svg%3E");
-        padding-right: 45px;
-        background-color: var(--bs-body-bg);
-        background-image: var(--bs-form-search-bg-img), var(--bs-form-search-bg-icon, none);
-        background-repeat: no-repeat;
-        background-position: right $form-select-padding-x center;
-        background-size: $form-select-bg-size;
+	input[type="search"] {
+		--bs-form-search-bg-img: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' class='bi bi-search' viewBox='0 0 16 16'%3E%3Cpath d='M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0'/%3E%3C/svg%3E");
+		padding-right: 45px;
+		background-color: var(--bs-body-bg);
+		background-image: var(--bs-form-search-bg-img),
+			var(--bs-form-search-bg-icon, none);
+		background-repeat: no-repeat;
+		background-position: right $form-select-padding-x center;
+		background-size: $form-select-bg-size;
 
-        &::-webkit-search-cancel-button {
-            position: relative;
-            -webkit-appearance: none;
-            width: 16px;
-            height: 16px;
-            top: 50%;
-            right: -10px;
-            padding-right: 7px;
-            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 18 18' fill='none'%3E%3Cpath d='M2.37414 3.30934C2.15816 3.09336 2.15816 2.7432 2.37414 2.52722C2.59012 2.31124 2.94029 2.31124 3.15627 2.52722L8.8487 8.21966L14.5411 2.52722C14.7571 2.31124 15.1073 2.31124 15.3233 2.52722C15.5392 2.7432 15.5392 3.09336 15.3233 3.30934L9.63083 9.00178L15.3233 14.6942C15.5392 14.9102 15.5392 15.2604 15.3233 15.4763C15.1073 15.6923 14.7571 15.6923 14.5411 15.4763L8.84871 9.78391L3.15627 15.4763C2.94029 15.6923 2.59012 15.6923 2.37414 15.4763C2.15816 15.2604 2.15816 14.9102 2.37414 14.6942L8.06658 9.00178L2.37414 3.30934Z' fill='%234B4B4B'/%3E%3C/svg%3E");
-            background-repeat: no-repeat;
-            border-right: 1px solid #D9D9D9;
-            transform: translateY(-50%);
-        }
-    }
+		&::-webkit-search-cancel-button {
+			position: relative;
+			-webkit-appearance: none;
+			width: 16px;
+			height: 16px;
+			right: -10px;
+			padding-right: 7px;
+			background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 18 18' fill='none'%3E%3Cpath d='M2.37414 3.30934C2.15816 3.09336 2.15816 2.7432 2.37414 2.52722C2.59012 2.31124 2.94029 2.31124 3.15627 2.52722L8.8487 8.21966L14.5411 2.52722C14.7571 2.31124 15.1073 2.31124 15.3233 2.52722C15.5392 2.7432 15.5392 3.09336 15.3233 3.30934L9.63083 9.00178L15.3233 14.6942C15.5392 14.9102 15.5392 15.2604 15.3233 15.4763C15.1073 15.6923 14.7571 15.6923 14.5411 15.4763L8.84871 9.78391L3.15627 15.4763C2.94029 15.6923 2.59012 15.6923 2.37414 15.4763C2.15816 15.2604 2.15816 14.9102 2.37414 14.6942L8.06658 9.00178L2.37414 3.30934Z' fill='%234B4B4B'/%3E%3C/svg%3E");
+			background-repeat: no-repeat;
+			border-right: 1px solid #d9d9d9;
+			transform: translateY(-50%);
+		}
+	}
 }
 
 .placeholder {
-    color: #d9d9d9;
-    border-radius: 4px;
+	color: #d9d9d9;
+	border-radius: 4px;
 
-    &-lg {
-        min-height: 32px;
-    }
+	&-lg {
+		min-height: 32px;
+	}
 }
 
 .programs-container-banner {
-    height: 200px;
+	height: 200px;
 }
 
 .tooltip .tooltip-inner {
-    font-family: var(--wp--preset--font-family--primary);
-    text-align: left;
+	font-family: var(--wp--preset--font-family--primary);
+	text-align: left;
 }
 
 // END MOVE TO UTKWDS


### PR DESCRIPTION
I added "format on save" working on the PHP formatting, so I accidentally pushed _a lot_ of changes. The main change was removing the `top: 50%;` property.

Not entirely sure why that wasn't doing anything on Chrome. Maybe double check my sanity on that?

Before:
<img width="211" alt="Screenshot 2025-06-26 at 4 01 40 PM" src="https://github.com/user-attachments/assets/91e09b20-7d43-452f-9342-de45661f00f7" />

After:
<img width="178" alt="Screenshot 2025-06-26 at 4 01 53 PM" src="https://github.com/user-attachments/assets/471d1b81-e9fc-40ca-87b0-69740f639f0f" />